### PR TITLE
HOTFIX: Change content_scripts to match with chrome patterns

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,7 @@
   "content_scripts": [
     {
       "matches": [
-        "*/time-tracker"
+        "*://*/time-tracker"
       ],
       "js": [
         "index.global.min.js",
@@ -32,7 +32,7 @@
     }
   ],
   "host_permissions": [
-    "*/time-tracker"
+    "*://*/time-tracker"
   ],
   "action": {},
   "devtools_page": "devtools.html"


### PR DESCRIPTION
Accordingly with [Google Match Patterns ](https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns) the URL should follow the format `<scheme>://<host>/<path>`.

That was causing an error when we tried to unload the extension on chrome (tested on Version 130.0.6723.91)